### PR TITLE
TEL-1668 Add ECS task for metrics source

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The following services and associated ECS tasks are deployed:
 | [kafdrop](https://github.com/obsidiandynamics/kafdrop) | [kafka/kafdrop/docker-compose.yml](kafka/kafdrop/docker-compose.yml) |
 | [ksql](https://github.com/confluentinc/ksql) | [kafka/ksql/docker-compose.yml](kafka/ksql/docker-compose.yml) |
 
+
+| Task | docker compose |
+|---:|:---|
+| [haggar](https://github.com/gorsuch/haggar) | [metrics/haggar/docker-compose.yml](metrics/haggar/docker-compose.yml) |
+
 NOTE: If external resource changes (for example MSK cluster) you'll need to re-deploy since service configurations are baked into ECS task and service definitions.
 
 ## Set-up
@@ -44,6 +49,14 @@ Do the following to create the stack:
 * `make ecs-svc-down # Bring the ECS services down`
 
 TODO: Automate SG rule to allow ECS to access MSK
+
+## Managing metric source
+
+Do the following to manage the metrics source workflow:
+* `cd metrics/haggar`
+* `make ecs-create # Create the metrics task`
+* `make ecs-up # Run the metrics task`
+* `make ecs-down # Stop the metrics task`
 
 ## SSH tunnel to ECS EC2 host
 

--- a/metrics/haggar/Makefile
+++ b/metrics/haggar/Makefile
@@ -1,0 +1,17 @@
+include ../../common.mk
+
+ecs-create:
+	ecs-cli compose --cluster $(ECS_CLUSTER_NAME) create
+.PHONY: ecs-create
+
+ecs-up:
+	ecs-cli compose --cluster $(ECS_CLUSTER_NAME) up
+.PHONY: ecs-up
+
+ecs-down:
+	ecs-cli compose --cluster $(ECS_CLUSTER_NAME) down
+.PHONY: ecs-down
+
+ecs-config:
+	@docker-compose config
+.PHONY: ecs-config

--- a/metrics/haggar/docker-compose.yml
+++ b/metrics/haggar/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  haggar:
+    image: egaillardon/haggar:1.0.1
+    command:
+      - -carbon=riemann-front:3003

--- a/metrics/haggar/ecs-params.yml
+++ b/metrics/haggar/ecs-params.yml
@@ -1,0 +1,12 @@
+version: 1
+task_definition:
+  ecs_network_mode: awsvpc
+run_params:
+  network_configuration:
+    awsvpc_configuration:
+      subnets:
+        - ${ECS_SUBNET_1}
+        - ${ECS_SUBNET_2}
+        - ${ECS_SUBNET_3}
+      security_groups:
+        - ${ECS_SEC_GROUP}


### PR DESCRIPTION
Haggar is used as a metrics source, typically used for demonstrations.
ECS task is used to manage haggar within a telemetery cluster.